### PR TITLE
Update README.md

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,7 +8,7 @@ WhyDRS is a free educational resource about the financial markets in the United 
 
 If you'd like to help with the organization in any aspect, please check out the Project Board below for open issues across all repositories. If you'd like to assign yourself an issue, please @ [one of the admins](https://github.com/orgs/WhyDRS/people) to let them know to update the issue.
 
-[![Project Board](https://img.shields.io/badge/Project-Boards-blue)](https://github.com/orgs/whydrs/projects)
+[![Project Board](https://img.shields.io/badge/Project-Boards-blue)](https://github.com/orgs/WhyDRS/projects/3)
 
 [![Weekly Podcast](https://img.shields.io/badge/Weekly-Podcast-purple)](https://linktr.ee/takingstockpodcast)
 


### PR DESCRIPTION
Link Project Board to Issues Tracker

Currently, the ["Project Boards" button](https://github.com/WhyDRS) links to the screenshot below. To save a click, I made a pull request that links the button directly to the Issues Tracker. Thoughts?

![Screenshot 2025-01-16 at 2 46 17 PM](https://github.com/user-attachments/assets/81b29743-8706-45b4-bd60-9bf3ca885b10)
